### PR TITLE
chore(deps): Update LanguageTool image to 5.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM erikvl87/languagetool:4.8
+FROM erikvl87/languagetool:5.2
 # https://github.com/Erikvl87/docker-languagetool
 
 ENV REVIEWDOG_VERSION=v0.11.0
 ENV TMPL_VERSION=v1.2.0
 ENV OFFSET_VERSION=v1.0.6
-ENV LANGUAGETOOL_VERSION=4.8
+ENV LANGUAGETOOL_VERSION=5.2
 ENV GHGLOB_VERSION=v2.0.2
 
 USER root

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,7 +4,7 @@ set -eo pipefail
 API_ENDPOINT="${INPUT_CUSTOM_API_ENDPOINT}"
 if [ -z "${INPUT_CUSTOM_API_ENDPOINT}" ]; then
   API_ENDPOINT=http://localhost:8010
-  java -cp "/LanguageTool-${LANGUAGETOOL_VERSION}/languagetool-server.jar" org.languagetool.server.HTTPServer --port 8010 &
+  java -cp "/LanguageTool/languagetool-server.jar" org.languagetool.server.HTTPServer --port 8010 &
   sleep 3 # Wait the server statup.
 fi
 


### PR DESCRIPTION
**Description**

Changes introduced in pull-request:
- update the `erikvl87/languagetool` Docker image from 4.8 to 5.2
- adopt the execution of LanguageTool application