### PR TITLE
Fix git error introduced in git 2.35.2

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,6 +14,8 @@ if [ -n "${GITHUB_WORKSPACE}" ]; then
   cd "${GITHUB_WORKSPACE}" || exit
 fi
 
+git config --global --add safe.directory $GITHUB_WORKSPACE
+
 # https://languagetool.org/http-api/swagger-ui/#!/default/post_check
 DATA="language=${INPUT_LANGUAGE}"
 if [ -n "${INPUT_ENABLED_RULES}" ]; then


### PR DESCRIPTION
Git v2.35.2 spec changes are causing this action to error during run.

Related issues;

- https://github.com/reviewdog/action-misspell/issues/43
- https://github.com/reviewdog/action-misspell/issues/42
- https://github.com/reviewdog/reviewdog/issues/1158#issue-1202862728
- https://github.com/reviewdog/action-yamllint/issues/18

This PR follows the same process to fix the issue as the PR fix in action-yamllint.