### PR TITLE
update IFS to manage whitespaces in filepath

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -39,6 +39,9 @@ set -o noglob
 FILES="$(git ls-files | ghglob ${INPUT_PATTERNS})"
 set +o noglob
 
+# To manage whitespaces in filepath
+IFS=$(echo -en "\n\b")
+
 run_langtool() {
   for FILE in ${FILES}; do
     echo "Checking ${FILE}..." >&2


### PR DESCRIPTION
Hi,

Currently, we have a failure when executing languagetool actions over directory name containing whitespaces.
For example, directory 'Architecture Cloud' gives the following error:
![image](https://github.com/reviewdog/action-languagetool/assets/65537062/8a083109-b1fb-4697-84ab-b40b468193ca)

Please could you review this PR to manage whitespaces in directory names.
Thanks.