### PR TITLE
Be able to configure the server startup waiting duration

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -37,6 +37,9 @@ inputs:
   custom_api_endpoint:
     description: 'Custom API endpoint of LanguageTool server. e.g. https://languagetool.org/api'
     default: ''
+  wait_server_startup_duration:
+    description: 'Custom API endpoint of LanguageTool server. e.g. https://languagetool.org/api'
+    default: '3'
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,6 +5,7 @@ API_ENDPOINT="${INPUT_CUSTOM_API_ENDPOINT}"
 if [ -z "${INPUT_CUSTOM_API_ENDPOINT}" ]; then
   API_ENDPOINT=http://localhost:8010
   java -cp "/LanguageTool/languagetool-server.jar" org.languagetool.server.HTTPServer --port 8010 &
+  echo "Wait the server startup for ${INPUT_WAIT_SERVER_STARTUP_DURATION}s"
   sleep "${INPUT_WAIT_SERVER_STARTUP_DURATION}" # Wait the server startup.
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,7 +5,7 @@ API_ENDPOINT="${INPUT_CUSTOM_API_ENDPOINT}"
 if [ -z "${INPUT_CUSTOM_API_ENDPOINT}" ]; then
   API_ENDPOINT=http://localhost:8010
   java -cp "/LanguageTool/languagetool-server.jar" org.languagetool.server.HTTPServer --port 8010 &
-  sleep 3 # Wait the server statup.
+  sleep "${INPUT_WAIT_SERVER_STARTUP_DURATION}" # Wait the server startup.
 fi
 
 echo "API ENDPOINT: ${API_ENDPOINT}" >&2


### PR DESCRIPTION
We use the reviewdog/action-languagetool. but sometimes,  we have failures because the server take more than 3s to be ready and curl call an unavailable localhost:8010.
We would like to be able do define the waiting duration.