### PR TITLE
fix: text parameter from file

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -49,7 +49,7 @@ run_langtool() {
     curl --silent \
       --request POST \
       --data "${DATA}" \
-      --data-urlencode "text=$(cat "${FILE}")" \
+      --data-urlencode "text@${FILE}" \
       "${API_ENDPOINT}/v2/check" | \
       FILE="${FILE}" tmpl /langtool.tmpl
   done


### PR DESCRIPTION
## Background

inlined `cat`ing of a file in the curl command can cause problems with shell escape characters. Especially if the text/markdown file at hand is large and contains a lot of special characters like [this example from the IPFS Docs, where I discovered this bug]https://github.com/ipfs/ipfs-docs/blob/84a4445592a6763796f92aa972d0a529e8d193c3/docs/reference/kubo/cli.md). 

This causes the problems mentioned in https://github.com/reviewdog/action-languagetool/issues/32

## What's in this PR

This changes uses the `fieldname@filename` [pattern in Curl](https://curl.se/docs/manpage.html#--data-urlencode) to have CURL load the contents of the file. 

This fixes #32 and has been confirmed to work in https://github.com/ipfs/ipfs-docs/actions/runs/12884342273/job/35920448036#step:4:448 


